### PR TITLE
fix vae loading order

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -240,6 +240,8 @@ def initialize():
     modelloader.cleanup_models()
     configure_opts_onchange()
 
+    modules.sd_vae.refresh_vae_list()
+    startup_timer.record("refresh VAE")
     modules.sd_models.setup_model()
     startup_timer.record("setup SD model")
 
@@ -283,8 +285,6 @@ def initialize_rest(*, reload_script_modules=False):
     modelloader.load_upscalers()
     startup_timer.record("load upscalers")
 
-    modules.sd_vae.refresh_vae_list()
-    startup_timer.record("refresh VAE")
     modules.textual_inversion.textual_inversion.list_textual_inversion_templates()
     startup_timer.record("refresh textual inversion templates")
 


### PR DESCRIPTION
## Description

* fix vae loading order: call `sd_vae.refresh_vae_list()` before `modules.sd_models.setup_model()`

## Screenshots/videos:
before
~~~bash
...
Couldn't find VAE named kl-f8-anime2.ckpt; using None instead
~~~
after
~~~bash
...
Loading VAE weights specified in settings: F:\webui\webui\stable-diffusion-webui\models\VAE\kl-f8-anime2.ckpt
~~~
## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
