### PR TITLE
xyz_grid: add prepare option to AxisOption

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -205,13 +205,14 @@ def csv_string_to_list_strip(data_str):
 
 
 class AxisOption:
-    def __init__(self, label, type, apply, format_value=format_value_add_label, confirm=None, cost=0.0, choices=None):
+    def __init__(self, label, type, apply, format_value=format_value_add_label, confirm=None, cost=0.0, choices=None, prepare=None):
         self.label = label
         self.type = type
         self.apply = apply
         self.format_value = format_value
         self.confirm = confirm
         self.cost = cost
+        self.prepare = prepare
         self.choices = choices
 
 
@@ -536,6 +537,8 @@ class Script(scripts.Script):
 
             if opt.choices is not None and not csv_mode:
                 valslist = vals_dropdown
+            elif opt.prepare is not None:
+                valslist = opt.prepare(vals)
             else:
                 valslist = csv_string_to_list_strip(vals)
 


### PR DESCRIPTION
## Description

* add `prepare` option to AxisOption to support raw inputs
* with this change, one can add entries line by line with or without commas.

## Screenshots/videos:
![image](https://github.com/wkpark/stable-diffusion-webui/assets/232347/3656c3a7-2db7-4781-8935-0a1fdee13fb8)

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
